### PR TITLE
Allowing commands to be invoked directly from host cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,4 +134,8 @@ vorpal.command('stats', 'Show statistics from your Pomodoros.').action((args, cb
   cb()
 })
 
+vorpal
+  .on('client_command_executed', evt => process.exit(0))
+  .parse(process.argv)
+
 vorpal.delimiter('🍅 ').show()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomd",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "description": "Just a good old cli based Pomodoro timer with native notifactions",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hello,

This PR allows the module to be invoked as

```
$hostcli ~ pomd start -t 50m -c 10m -t 50m -c 25m --loop
```

making it more flexible, and hiding vorpal somewhat :) 