### PR TITLE
Fix package.json not valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,8 @@
     "piggy-bank": "^2.0.0",
     "timrjs": "^1.0.1",
     "vorpal": "^1.12.0",
-    "snyk": "^1.316.1"
-    "update-notifier": "^4.0.0",
-    "vorpal": "^1.12.0"
+    "snyk": "^1.316.1",
+    "update-notifier": "^4.0.0"
   },
   "devDependencies": {
     "standard": "14.3.1"


### PR DESCRIPTION
Duplicate vorpal package, and missing comma

Resolve:
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected string in JSON at position 872 while parsing '{
npm ERR! JSON.parse   "name": "pomd",
npm ERR! JSON.parse   "version": "2.4.'
npm ERR! JSON.parse Failed to parse package.json data.
npm ERR! JSON.parse package.json must be actual JSON, not just JavaScript.